### PR TITLE
アカウント画面の情報編集タブでアイコンが変えられないエラーを修正

### DIFF
--- a/src/main/java/jp/co/suyama/menu/deliver/mapper/UsersMapperImpl.java
+++ b/src/main/java/jp/co/suyama/menu/deliver/mapper/UsersMapperImpl.java
@@ -58,6 +58,8 @@ public interface UsersMapperImpl extends UsersMapper {
       , "set"
       , "  email = #{email,jdbcType=VARCHAR},"
       , "  password = #{password,jdbcType=VARCHAR},"
+      , "  name = #{name,jdbcType=VARCHAR},"
+      , "  icon = #{icon,jdbcType=VARCHAR},"
       , "  available = #{available,jdbcType=BIT},"
       , "  once_password = #{oncePassword,jdbcType=VARCHAR},"
       , "  expires = #{expires,jdbcType=TIMESTAMP},"

--- a/src/main/java/jp/co/suyama/menu/deliver/service/MenuService.java
+++ b/src/main/java/jp/co/suyama/menu/deliver/service/MenuService.java
@@ -321,7 +321,7 @@ public class MenuService {
             menuCompArray = objectMapper.readValue(contents, MenuComposition[].class);
         } catch (Exception e) {
             log.error("content: [{}]", contents);
-            throw new MenuDeliverException("献立内容の変換に失敗しました。");
+            throw new MenuDeliverException("献立内容の変換に失敗しました。", e);
         }
 
         // 重複しない食品番号のリストを取得する


### PR DESCRIPTION
Fixed #2 

更新処理のSQLでニックネームとアイコンを更新していなかった。